### PR TITLE
add a dedicated s3 resource for each buildpack

### DIFF
--- a/operators/artifactory.yml
+++ b/operators/artifactory.yml
@@ -7,76 +7,110 @@
       repository: orangeopensource/artifactory-resource
 
 - type: replace
-  path: /resources/name=buildpack-store/type
+  path: /resources/name=buildpack-store?/type
   value: artifactory
 
 - type: replace
-  path: /resources/name=buildpack-store/source
+  path: /resources/name=buildpack-store?/source
   value:
     url: ((artifactory-url))
     user: ((artifactory-username))
     password: ((artifactory-password))
 
-# go
+- type: remove
+  path: /resources/name=php-buildpack-store
+- type: remove
+  path: /resources/name=go-buildpack-store
+- type: remove
+  path: /resources/name=ruby-buildpack-store
+- type: remove
+  path: /resources/name=python-buildpack-store
+- type: remove
+  path: /resources/name=binary-buildpack-store
+- type: remove
+  path: /resources/name=staticfile-buildpack-store
+- type: remove
+  path: /resources/name=java-buildpack-store
+- type: remove
+  path: /resources/name=nodejs-buildpack-store
+
+
+# php
 - type: replace
-  path: /jobs/name=deploy-php/plan/put=buildpack-store/params
+  path: /jobs/name=deploy-php/plan/put=php-buildpack-store
   value:
-    target: cloudfoundry_buildpack_php/
-    source: "*.zip"
+    put: buildpack-store
+    params:
+      target: cloudfoundry_buildpack_php/
+      source: "*.zip"
 #####
 
 # go
 - type: replace
-  path: /jobs/name=deploy-go/plan/put=buildpack-store/params
+  path: /jobs/name=deploy-go/plan/put=go-buildpack-store
   value:
-    target: cloudfoundry_buildpack_go/
-    source: "*.zip"
+    put: buildpack-store
+    params:
+      target: cloudfoundry_buildpack_go/
+      source: "*.zip"
 #####
 
 # ruby
 - type: replace
-  path: /jobs/name=deploy-ruby/plan/put=buildpack-store/params
+  path: /jobs/name=deploy-ruby/plan/put=ruby-buildpack-store
   value:
-    target: cloudfoundry_buildpack_ruby/
-    source: "*.zip"
+    put: buildpack-store
+    params:
+      target: cloudfoundry_buildpack_ruby/
+      source: "*.zip"
 #####
 
 # python
 - type: replace
-  path: /jobs/name=deploy-python/plan/put=buildpack-store/params
+  path: /jobs/name=deploy-python/plan/put=python-buildpack-store
   value:
-    target: cloudfoundry_buildpack_python/
-    source: "*.zip"
+    put: buildpack-store
+    params:
+      target: cloudfoundry_buildpack_python/
+      source: "*.zip"
 #####
 
 # binary
 - type: replace
-  path: /jobs/name=deploy-binary/plan/put=buildpack-store/params
+  path: /jobs/name=deploy-binary/plan/put=binary-buildpack-store
   value:
-    target: cloudfoundry_buildpack_binary/
-    source: "*.zip"
+    put: buildpack-store
+    params:
+      target: cloudfoundry_buildpack_binary/
+      source: "*.zip"
 #####
 
 # staticfile
 - type: replace
-  path: /jobs/name=deploy-staticfile/plan/put=buildpack-store/params
+  path: /jobs/name=deploy-staticfile/plan/put=staticfile-buildpack-store
   value:
-    target: cloudfoundry_buildpack_staticfile/
-    source: "*.zip"
+    put: buildpack-store
+    params:
+      target: cloudfoundry_buildpack_staticfile/
+      source: "*.zip"
 #####
 
 # java
 - type: replace
-  path: /jobs/name=deploy-java/plan/put=buildpack-store/params
+  path: /jobs/name=deploy-java/plan/put=java-buildpack-store
   value:
-    target: cloudfoundry_buildpack_java/
-    source: "*.zip"
+    put: buildpack-store
+    params:
+      target: cloudfoundry_buildpack_java/
+      source: "*.zip"
 #####
 
 # nodejs
 - type: replace
-  path: /jobs/name=deploy-nodejs/plan/put=buildpack-store/params
+  path: /jobs/name=deploy-nodejs/plan/put=nodejs-buildpack-store
   value:
-    target: cloudfoundry_buildpack_nodejs/
-    source: "*.zip"
+    put: buildpack-store
+    params:
+      target: cloudfoundry_buildpack_nodejs/
+      source: "*.zip"
 #####

--- a/operators/custom-s3.yml
+++ b/operators/custom-s3.yml
@@ -1,3 +1,25 @@
 - type: replace
-  path: /resources/name=buildpack-store/source/endpoint?
+  path: /resources/name=php-buildpack-store/source/endpoint?
   value: ((s3_endpoint))
+- type: replace
+  path: /resources/name=go-buildpack-store/source/endpoint?
+  value: ((s3_endpoint))
+- type: replace
+  path: /resources/name=ruby-buildpack-store/source/endpoint?
+  value: ((s3_endpoint))
+- type: replace
+  path: /resources/name=python-buildpack-store/source/endpoint?
+  value: ((s3_endpoint))
+- type: replace
+  path: /resources/name=binary-buildpack-store/source/endpoint?
+  value: ((s3_endpoint))
+- type: replace
+  path: /resources/name=staticfile-buildpack-store/source/endpoint?
+  value: ((s3_endpoint))
+- type: replace
+  path: /resources/name=java-buildpack-store/source/endpoint?
+  value: ((s3_endpoint))
+- type: replace
+  path: /resources/name=nodejs-buildpack-store/source/endpoint?
+  value: ((s3_endpoint))
+

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,10 +1,69 @@
 resources:
-- name: buildpack-store
+- name: php-buildpack-store
   type: s3
   source:
     bucket: ((s3_bucket))
     access_key_id: ((s3_access_key_id))
     secret_access_key: ((s3_secret_access_key))
+    regexp: php_buildpack-cached-v(.*).zip
+
+- name: go-buildpack-store
+  type: s3
+  source:
+    bucket: ((s3_bucket))
+    access_key_id: ((s3_access_key_id))
+    secret_access_key: ((s3_secret_access_key))
+    regexp: go_buildpack-cached-v(.*).zip
+
+- name: ruby-buildpack-store
+  type: s3
+  source:
+    bucket: ((s3_bucket))
+    access_key_id: ((s3_access_key_id))
+    secret_access_key: ((s3_secret_access_key))
+    regexp: ruby_buildpack-cached-v(.*).zip
+
+- name: python-buildpack-store
+  type: s3
+  source:
+    bucket: ((s3_bucket))
+    access_key_id: ((s3_access_key_id))
+    secret_access_key: ((s3_secret_access_key))
+    regexp: python_buildpack-cached-v(.*).zip
+
+- name: binary-buildpack-store
+  type: s3
+  source:
+    bucket: ((s3_bucket))
+    access_key_id: ((s3_access_key_id))
+    secret_access_key: ((s3_secret_access_key))
+    regexp: binary_buildpack-cached-v(.*).zip
+
+- name: staticfile-buildpack-store
+  type: s3
+  source:
+    bucket: ((s3_bucket))
+    access_key_id: ((s3_access_key_id))
+    secret_access_key: ((s3_secret_access_key))
+    regexp: staticfile_buildpack-cached-v(.*).zip
+
+- name: nodejs-buildpack-store
+  type: s3
+  source:
+    bucket: ((s3_bucket))
+    access_key_id: ((s3_access_key_id))
+    secret_access_key: ((s3_secret_access_key))
+    regexp: nodejs_buildpack-cached-v(.*).zip
+
+- name: java-buildpack-store
+  type: s3
+  source:
+    bucket: ((s3_bucket))
+    access_key_id: ((s3_access_key_id))
+    secret_access_key: ((s3_secret_access_key))
+    regexp: java-buildpack-offline-v(.*).zip
+
+
 - name: ci-scripts
   type: git
   source:
@@ -100,7 +159,7 @@ jobs:
       run:
         path: ci-scripts/scripts/ruby-packager.sh
         args: [php]
-  - put: buildpack-store
+  - put: php-buildpack-store
     params:
       file: "bp-cached/*.zip"
 
@@ -127,7 +186,7 @@ jobs:
       run:
         path: ci-scripts/scripts/go-packager.sh
         args: [go]
-  - put: buildpack-store
+  - put: go-buildpack-store
     params:
       file: "bp-cached/*.zip"
 
@@ -154,7 +213,7 @@ jobs:
       run:
         path: ci-scripts/scripts/go-packager.sh
         args: [ruby]
-  - put: buildpack-store
+  - put: ruby-buildpack-store
     params:
       file: "bp-cached/*.zip"
 
@@ -180,7 +239,7 @@ jobs:
       run:
         path: ci-scripts/scripts/go-packager.sh
         args: [python]
-  - put: buildpack-store
+  - put: python-buildpack-store
     params:
       file: "bp-cached/*.zip"
 
@@ -206,7 +265,7 @@ jobs:
       run:
         path: ci-scripts/scripts/go-packager.sh
         args: [binary]
-  - put: buildpack-store
+  - put: binary-buildpack-store
     params:
       file: "bp-cached/*.zip"
 
@@ -232,7 +291,7 @@ jobs:
       run:
         path: ci-scripts/scripts/go-packager.sh
         args: [staticfile]
-  - put: buildpack-store
+  - put: staticfile-buildpack-store
     params:
       file: "bp-cached/*.zip"
 
@@ -260,7 +319,7 @@ jobs:
       run:
         path: ci-scripts/scripts/rake-packager.sh
         args: [java]
-  - put: buildpack-store
+  - put: java-buildpack-store
     params:
       file: "bp-cached/*.zip"
 
@@ -286,7 +345,7 @@ jobs:
       run:
         path: ci-scripts/scripts/go-packager.sh
         args: [nodejs]
-  - put: buildpack-store
+  - put: nodejs-buildpack-store
     params:
       file: "bp-cached/*.zip"
 

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -102,7 +102,7 @@ jobs:
         args: [php]
   - put: buildpack-store
     params:
-      file: "*.zip"
+      file: "bp-cached/*.zip"
 
 
 - name: deploy-go
@@ -129,7 +129,7 @@ jobs:
         args: [go]
   - put: buildpack-store
     params:
-      file: "*.zip"
+      file: "bp-cached/*.zip"
 
 
 - name: deploy-ruby
@@ -156,7 +156,7 @@ jobs:
         args: [ruby]
   - put: buildpack-store
     params:
-      file: "*.zip"
+      file: "bp-cached/*.zip"
 
 - name: deploy-python
   serial: true
@@ -182,7 +182,7 @@ jobs:
         args: [python]
   - put: buildpack-store
     params:
-      file: "*.zip"
+      file: "bp-cached/*.zip"
 
 - name: deploy-binary
   serial: true
@@ -208,7 +208,7 @@ jobs:
         args: [binary]
   - put: buildpack-store
     params:
-      file: "*.zip"
+      file: "bp-cached/*.zip"
 
 - name: deploy-staticfile
   serial: true
@@ -234,7 +234,7 @@ jobs:
         args: [staticfile]
   - put: buildpack-store
     params:
-      file: "*.zip"
+      file: "bp-cached/*.zip"
 
 - name: deploy-java
   serial: true
@@ -262,7 +262,7 @@ jobs:
         args: [java]
   - put: buildpack-store
     params:
-      file: "*.zip"
+      file: "bp-cached/*.zip"
 
 - name: deploy-nodejs
   serial: true
@@ -288,5 +288,5 @@ jobs:
         args: [nodejs]
   - put: buildpack-store
     params:
-      file: "*.zip"
+      file: "bp-cached/*.zip"
 


### PR DESCRIPTION
WARNING: this PR is based on #1

    We add a s3 resource with a customized regexp for each buildpack. Warning:
    java buildpack is still using 'offline' name. We keep a single resource for
    artifactory deployment. This is a new resource, it does not reuse
    configuration from s3 resource.

    closed #3