### PR TITLE
optimize and fix usage for concourse 7 and later

### DIFF
--- a/operators/add-trigger-all-jobs.yml
+++ b/operators/add-trigger-all-jobs.yml
@@ -2,7 +2,7 @@
   path: /resource_types?/name=fly-resource?
   value:
     name: fly-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: orangecloudfoundry/concourse-fly-resource
       tag: latest
@@ -11,7 +11,7 @@
   path: /resource_types?/name=cron-resource?
   value:
     name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: cftoolsmiths/cron-resource
 

--- a/operators/add-trigger-all-jobs.yml
+++ b/operators/add-trigger-all-jobs.yml
@@ -45,7 +45,7 @@
   value:
     name: retrigger-all
     plan:
-      - aggregate:
+      - in_parallel:
           - get: weekday-morning
             trigger: true
       - put: fly

--- a/operators/artifactory.yml
+++ b/operators/artifactory.yml
@@ -2,7 +2,7 @@
   path: /resource_types?/-
   value:
     name: artifactory
-    type: docker-image
+    type: registry-image
     source:
       repository: orangeopensource/artifactory-resource
 

--- a/operators/detect-previous-versions.yml
+++ b/operators/detect-previous-versions.yml
@@ -45,7 +45,7 @@
   value:
     name: detect-previous-versions
     plan:
-      - aggregate:
+      - in_parallel:
           - get: weekday-morning
             trigger: true
       - put: fly

--- a/operators/detect-previous-versions.yml
+++ b/operators/detect-previous-versions.yml
@@ -2,7 +2,7 @@
   path: /resource_types?/name=fly-resource?
   value:
     name: fly-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: orangecloudfoundry/concourse-fly-resource
       tag: latest
@@ -11,7 +11,7 @@
   path: /resource_types?/name=cron-resource?
   value:
     name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: cftoolsmiths/cron-resource
 

--- a/operators/slack-notify.yml
+++ b/operators/slack-notify.yml
@@ -2,7 +2,7 @@
   path: /resource_types?/-
   value:
     name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
       repository: cfcommunity/slack-notification-resource
       tag: latest

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -206,7 +206,7 @@ jobs:
 - name: deploy-php
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci-scripts
     - get: php-bp-release
       trigger: true
@@ -235,7 +235,7 @@ jobs:
 - name: deploy-go
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci-scripts
     - get: go-bp-release
       trigger: true
@@ -264,7 +264,7 @@ jobs:
 - name: deploy-ruby
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci-scripts
     - get: ruby-bp-release
       trigger: true
@@ -293,7 +293,7 @@ jobs:
 - name: deploy-python
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci-scripts
     - get: python-bp-release
       trigger: true
@@ -322,7 +322,7 @@ jobs:
 - name: deploy-binary
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci-scripts
     - get: binary-bp-release
       trigger: true
@@ -351,7 +351,7 @@ jobs:
 - name: deploy-staticfile
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci-scripts
     - get: staticfile-bp-release
       trigger: true
@@ -380,7 +380,7 @@ jobs:
 - name: deploy-java
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci-scripts
     - get: java-bp-release
       params:
@@ -408,7 +408,7 @@ jobs:
 - name: deploy-nodejs
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci-scripts
     - get: nodejs-bp-release
       trigger: true

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -214,7 +214,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: { repository: orangeopensource/concourse, tag: "buildpack" }
       inputs:
       - name: php-bp-release
@@ -243,7 +243,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: { repository: orangeopensource/concourse, tag: "buildpack" }
       inputs:
       - name: go-bp-release

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -272,7 +272,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: { repository: orangeopensource/concourse, tag: "buildpack" }
       inputs:
       - name: ruby-bp-release
@@ -301,7 +301,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: { repository: orangeopensource/concourse, tag: "buildpack" }
       inputs:
       - name: python-bp-release
@@ -330,7 +330,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: { repository: orangeopensource/concourse, tag: "buildpack" }
       inputs:
       - name: binary-bp-release
@@ -359,7 +359,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: { repository: orangeopensource/concourse, tag: "buildpack" }
       inputs:
       - name: staticfile-bp-release
@@ -390,7 +390,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: { repository: orangeopensource/concourse, tag: "buildpack" }
       inputs:
       - name: java-bp-release
@@ -416,7 +416,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: { repository: orangeopensource/concourse, tag: "buildpack" }
       inputs:
       - name: nodejs-bp-release

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -385,6 +385,8 @@ jobs:
     - get: java-bp-release
       params:
         include_source_tarball: true
+        globs:
+          - "s*gz"
       trigger: true
   - task: deploy-java
     config:


### PR DESCRIPTION
We include couple of optimization:
* java-bp: only download sources file from github release
* switch resource type to 'registry-image'
* use in_parallel instead of aggregate