### PR TITLE
Switch to embedded time resource

### DIFF
--- a/.github/workflows/build-concourse-image.yml
+++ b/.github/workflows/build-concourse-image.yml
@@ -1,0 +1,34 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: build, test and publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    -
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    -
+      name: build and publish 'buildpack' image
+      uses: docker/build-push-action@v4.0.0
+      with:
+        context: buildpack-image
+        push: true
+        tags: |          
+          ghcr.io/${{github.repository}}:${{github.sha}}
+          ghcr.io/${{github.repository}}:latest
+

--- a/buildpack-image/Dockerfile
+++ b/buildpack-image/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:3.1-slim
+
+ARG BOSH_CLI_VERSION="7.2.0"
+
+ENV PACKAGES "bash curl openssh-client file git openssl ca-certificates wget libffi-dev zip gcc ruby-dev make"
+
+RUN gem install bundler -v 2.4.8
+
+RUN apt-get update && apt-get install -y $PACKAGES && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq
+
+RUN curl -L 'https://dl.google.com/go/go1.20.2.linux-amd64.tar.gz' -o go.tar.gz && tar -C /usr/local -xzf go.tar.gz && rm -f go.tar.gz
+
+RUN curl -L "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64" -o /usr/local/bin/bosh \
+&& chmod +x /usr/local/bin/bosh
+
+RUN mkdir -p /gopath/bin
+ENV GOPATH /gopath
+ENV GOBIN /gopath/bin
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/buildpack-image/Dockerfile
+++ b/buildpack-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1-slim
+FROM ruby:3.0-slim
 
 ARG BOSH_CLI_VERSION="7.2.0"
 

--- a/buildpack-image/README.md
+++ b/buildpack-image/README.md
@@ -1,0 +1,8 @@
+Container used to create cached buildpack
+
+# What is inside ?
+
+- `ruby`
+- `git`
+- `curl`
+- `jq` - https://github.com/stedolan/jq

--- a/operators/add-trigger-all-jobs.yml
+++ b/operators/add-trigger-all-jobs.yml
@@ -5,25 +5,18 @@
     type: registry-image
     source:
       repository: orangecloudfoundry/concourse-fly-resource
-      tag: latest
-
-- type: replace
-  path: /resource_types?/name=cron-resource?
-  value:
-    name: cron-resource
-    type: registry-image
-    source:
-      repository: cftoolsmiths/cron-resource
+      tag: 2.0.1-orange
 
 - type: replace
   path: /resources/name=weekday-morning?
   value:
     name: weekday-morning
-    type: cron-resource
+    type: time
     source:
-      expression: 40 8 * * 1-5
-      fire_immediately: true
       location: Europe/Paris
+      start: 8:00
+      stop: 9:00
+      days: [ Monday, Tuesday, Wednesday, Thursday, Friday ]
 
 - type: replace
   path: /resources/name=fly?

--- a/operators/add-trigger-all-jobs.yml
+++ b/operators/add-trigger-all-jobs.yml
@@ -4,8 +4,8 @@
     name: fly-resource
     type: registry-image
     source:
-      repository: orangecloudfoundry/concourse-fly-resource
-      tag: 2.0.1-orange
+      repository: elpaasoci/concourse-fly-resource
+      tag: 2.0.2-orange
 
 - type: replace
   path: /resources/name=weekday-morning?

--- a/operators/detect-previous-versions.yml
+++ b/operators/detect-previous-versions.yml
@@ -5,25 +5,18 @@
     type: registry-image
     source:
       repository: orangecloudfoundry/concourse-fly-resource
-      tag: latest
-
-- type: replace
-  path: /resource_types?/name=cron-resource?
-  value:
-    name: cron-resource
-    type: registry-image
-    source:
-      repository: cftoolsmiths/cron-resource
+      tag: 2.0.1-orange
 
 - type: replace
   path: /resources/name=weekday-morning?
   value:
     name: weekday-morning
-    type: cron-resource
+    type: time
     source:
-      expression: 40 8 * * 1-5
-      fire_immediately: true
       location: Europe/Paris
+      start: 8:00
+      stop: 9:00
+      days: [ Monday, Tuesday, Wednesday, Thursday, Friday ]
 
 - type: replace
   path: /resources/name=fly?

--- a/operators/detect-previous-versions.yml
+++ b/operators/detect-previous-versions.yml
@@ -4,8 +4,8 @@
     name: fly-resource
     type: registry-image
     source:
-      repository: orangecloudfoundry/concourse-fly-resource
-      tag: 2.0.1-orange
+      repository: elpaasoci/concourse-fly-resource
+      tag: 2.0.2-orange
 
 - type: replace
   path: /resources/name=weekday-morning?

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -215,7 +215,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: orangeopensource/concourse, tag: "buildpack" }
+        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
       inputs:
       - name: php-bp-release
         path: bp-release
@@ -244,7 +244,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: orangeopensource/concourse, tag: "buildpack" }
+        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
       inputs:
       - name: go-bp-release
         path: bp-release
@@ -273,7 +273,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: orangeopensource/concourse, tag: "buildpack" }
+        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
       inputs:
       - name: ruby-bp-release
         path: bp-release
@@ -302,7 +302,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: orangeopensource/concourse, tag: "buildpack" }
+        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
       inputs:
       - name: python-bp-release
         path: bp-release
@@ -331,7 +331,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: orangeopensource/concourse, tag: "buildpack" }
+        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
       inputs:
       - name: binary-bp-release
         path: bp-release
@@ -360,7 +360,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: orangeopensource/concourse, tag: "buildpack" }
+        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
       inputs:
       - name: staticfile-bp-release
         path: bp-release
@@ -393,7 +393,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: orangeopensource/concourse, tag: "buildpack" }
+        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
       inputs:
       - name: java-bp-release
         path: bp-release
@@ -419,7 +419,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: orangeopensource/concourse, tag: "buildpack" }
+        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
       inputs:
       - name: nodejs-bp-release
         path: bp-release

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -215,7 +215,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
+        source: { repository: ghcr.io/orange-cloudfoundry/ci-buildpack-cached, tag: latest }
       inputs:
       - name: php-bp-release
         path: bp-release
@@ -244,7 +244,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
+        source: { repository: ghcr.io/orange-cloudfoundry/ci-buildpack-cached, tag: latest }
       inputs:
       - name: go-bp-release
         path: bp-release
@@ -273,7 +273,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
+        source: { repository: ghcr.io/orange-cloudfoundry/ci-buildpack-cached, tag: latest }
       inputs:
       - name: ruby-bp-release
         path: bp-release
@@ -302,7 +302,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
+        source: { repository: ghcr.io/orange-cloudfoundry/ci-buildpack-cached, tag: latest }
       inputs:
       - name: python-bp-release
         path: bp-release
@@ -331,7 +331,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
+        source: { repository: ghcr.io/orange-cloudfoundry/ci-buildpack-cached, tag: latest }
       inputs:
       - name: binary-bp-release
         path: bp-release
@@ -360,7 +360,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
+        source: { repository: ghcr.io/orange-cloudfoundry/ci-buildpack-cached, tag: latest }
       inputs:
       - name: staticfile-bp-release
         path: bp-release
@@ -393,7 +393,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
+        source: { repository: ghcr.io/orange-cloudfoundry/ci-buildpack-cached, tag: latest }
       inputs:
       - name: java-bp-release
         path: bp-release
@@ -419,7 +419,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: { repository: ghcr.io/orange-cloudfoundry/concourse-containers-buildpack, tag: latest }
+        source: { repository: ghcr.io/orange-cloudfoundry/ci-buildpack-cached, tag: latest }
       inputs:
       - name: nodejs-bp-release
         path: bp-release

--- a/scripts/go-packager.sh
+++ b/scripts/go-packager.sh
@@ -11,7 +11,7 @@ if [ -f "go.mod" ]; then
 	export PATH="$GOBIN:$PATH"
 	rm -f go.sum
 	go mod download
-	go install github.com/cloudfoundry/libbuildpack/packager/buildpack-packager
+	go install github.com/cloudfoundry/libbuildpack/packager/buildpack-packager@latest
 else
 	ln -s "${first_folder}/vendor" golib/src
 	cd src/*/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager


### PR DESCRIPTION
Time resource is mature and has feature parity with cron-resource, so we use it.

We also use a tagged version of concourse-fly-resource, to enhance reproducibility.

close #13